### PR TITLE
Add support to override Ajax HTTP headers

### DIFF
--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -120,7 +120,8 @@ sync = {
                     },
                     dataType: "json",
                     async : options.getAsync,
-                    timeout: options.ajaxTimeout
+                    timeout: options.ajaxTimeout,
+                    headers: options.headers
                 });
             }    
         }


### PR DESCRIPTION
With this patch it is possible to include a "headers" option when calling i18n.init() which may be used to override the default content-type and accept headers or to provide additional custom HTTP headers.

Example usage:

i18n.init({
headers: {'content-type': 'application/json'}
});